### PR TITLE
Update t5403.cpp

### DIFF
--- a/Libraries/Arduino/SFE_T5403/t5403.cpp
+++ b/Libraries/Arduino/SFE_T5403/t5403.cpp
@@ -97,9 +97,8 @@ int32_t T5403::getPressure(uint8_t commanded_precision)
 	getData(T5403_DATA_REG, &temperature_raw);		
 	
 	// Load measurement noise level into command along with start command bit.
-	commanded_precision = (commanded_precision << 3)|(0x01); 
 	// Start pressure measurement
-	sendCommand(T5403_COMMAND_REG, commanded_precision); 
+	sendCommand(T5403_COMMAND_REG, (commanded_precision << 3)|(0x01));  
 	
 	//Select delay time based on precision level selected.
 	switch(commanded_precision){


### PR DESCRIPTION
Bit shift changed value of 'commanded_precision' and broke the switch statement below.
